### PR TITLE
Adjust sidebar behavior and center chat header

### DIFF
--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -12,22 +12,22 @@ import { Logo } from '@/components/Logo';
 import { Header } from '@/components/Header';
 
 function ChatPageHeader() {
-    const { open } = useSidebar();
+    const { open, isMobile, openMobile } = useSidebar();
     return (
         <div className="flex items-center gap-2 h-16 absolute top-2 sm:top-4 left-2 sm:left-4 z-10">
-             {!open && (
+             {isMobile && !openMobile && (
             <>
               <SidebarTrigger asChild>
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8 sm:h-9 sm:w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-primary/10 transition-all duration-200 hover:scale-110"
+                  className="h-8 w-8 rounded-full text-muted-foreground hover:text-foreground hover:bg-primary/10 transition-all duration-200 hover:scale-110"
                 >
-                  <Menu className="h-4 w-4 sm:h-5 sm:w-5" />
+                  <Menu className="h-4 w-4" />
                   <span className="sr-only">Open menu</span>
                 </Button>
               </SidebarTrigger>
-              <Logo className="hidden sm:block" />
+              <Logo className="text-sm" />
             </>
           )}
         </div>
@@ -42,8 +42,8 @@ export default function ChatLayout({
 }>) {
   return (
     <ChatHistoryProvider>
-        <SidebarProvider defaultOpen={false} variant="sidebar">
-          <Sidebar className="border-r-0 sm:border-r">
+        <SidebarProvider defaultOpen={true} variant="sidebar">
+          <Sidebar className="border-r-0 sm:border-r" collapsible="offcanvas">
             <SidebarContent className="p-2 sm:p-4">
               <SidebarHeader>
                 <div className="flex items-center justify-between w-full">
@@ -52,10 +52,10 @@ export default function ChatLayout({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-8 w-8 sm:h-9 sm:w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-primary/10 transition-all duration-200 hover:scale-110"
+                      className="h-8 w-8 sm:h-9 sm:w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-primary/10 transition-all duration-200 hover:scale-110 sm:hidden"
                     >
                       <Menu className="h-4 w-4 sm:h-5 sm:w-5" />
-                      <span className="sr-only">Open menu</span>
+                      <span className="sr-only">Close menu</span>
                     </Button>
                   </SidebarTrigger>
                 </div>
@@ -68,7 +68,9 @@ export default function ChatLayout({
           <SidebarInset className='flex flex-col overflow-hidden'>
              <ChatPageHeader />
              <Header />
-            {children}
+            <div className="flex-1 overflow-hidden">
+              {children}
+            </div>
           </SidebarInset>
           <Toaster />
         </SidebarProvider>

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -132,7 +132,7 @@ export default function ChatPage() {
   }
 
   return (
-    <div className='flex flex-col h-full flex-1'>
+    <div className='flex flex-col h-full flex-1 min-h-0'>
       <main className="flex-1 overflow-y-auto">
         <div className="container mx-auto max-w-4xl py-4 sm:py-6 md:py-8 px-2 sm:px-4">
             <CropResults
@@ -142,7 +142,7 @@ export default function ChatPage() {
             />
         </div>
       </main>
-      <div className="bg-gradient-to-t from-background to-transparent">
+      <div className="flex-shrink-0 bg-gradient-to-t from-background to-transparent">
         <div className="container mx-auto max-w-4xl p-2 sm:p-4 flex flex-col items-center">
             <SuggestionPrompts onSuggestionClick={handleSuggestionClick} />
             <PromptForm

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,14 @@
     --input: 220 13% 91%;
     --ring: 262 82% 56%;
     --light-green: 140 70% 90%;
+    --sidebar-background: 220 20% 100%;
+    --sidebar-foreground: 240 10% 3.9%;
+    --sidebar-primary: 262 82% 56%;
+    --sidebar-primary-foreground: 262 82% 96%;
+    --sidebar-accent: 220 14% 96%;
+    --sidebar-accent-foreground: 240 10% 3.9%;
+    --sidebar-border: 220 13% 91%;
+    --sidebar-ring: 262 82% 56%;
   }
   .dark {
     --background: 220 15% 10%;
@@ -47,6 +55,14 @@
     --input: 220 10% 18%;
     --ring: 262 82% 61%;
     --light-green: 140 70% 15%;
+    --sidebar-background: 220 12% 12%;
+    --sidebar-foreground: 220 10% 95%;
+    --sidebar-primary: 262 82% 61%;
+    --sidebar-primary-foreground: 220 10% 98%;
+    --sidebar-accent: 220 10% 15%;
+    --sidebar-accent-foreground: 220 10% 98%;
+    --sidebar-border: 220 10% 20%;
+    --sidebar-ring: 262 82% 61%;
   }
 
   * {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -48,12 +48,14 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-50 w-full p-2 sm:p-4">
-      <div className="container relative flex h-16 items-center justify-between mx-auto max-w-4xl">
+      <div className="container relative flex h-16 items-center justify-center mx-auto max-w-4xl">
         {/* Mobile Menu */}
         {isMobile ? (
           <>
-            <Logo />
-            <div className="flex items-center gap-2">
+            <div className="absolute left-0 flex items-center">
+              <Logo />
+            </div>
+            <div className="absolute right-0 flex items-center gap-2">
               <LanguageSwitcher />
               <ThemeToggle />
               <ProfileButton />
@@ -107,12 +109,12 @@ export function Header() {
           </>
         ) : (
           <>
-            {/* Desktop Navigation */}
+            {/* Desktop Navigation - Centered */}
             <div className="flex items-center gap-2 bg-card/50 backdrop-blur-sm border border-primary/10 rounded-full p-2">
               <NavLinks />
               <LanguageSwitcher />
             </div>
-            <div className="absolute top-4 right-4 flex items-center gap-2 h-16">
+            <div className="absolute right-0 flex items-center gap-2">
               <ThemeToggle />
               <ProfileButton />
             </div>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -95,15 +95,23 @@ const SidebarProvider = React.forwardRef<
     const toggleSidebar = React.useCallback(() => {
       return isMobile
         ? setOpenMobile((open) => !open)
-        : setOpen((open) => !open)
-    }, [isMobile, setOpen, setOpenMobile])
+        : null // Don't allow toggle on desktop - sidebar stays open
+    }, [isMobile, setOpenMobile])
 
-    // Adds a keyboard shortcut to toggle the sidebar.
+    // Ensure desktop sidebar stays open when switching from mobile to desktop
+    React.useEffect(() => {
+      if (!isMobile && !open) {
+        setOpen(true)
+      }
+    }, [isMobile, open, setOpen])
+
+    // Adds a keyboard shortcut to toggle the sidebar (mobile only).
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
         if (
           event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-          (event.metaKey || event.ctrlKey)
+          (event.metaKey || event.ctrlKey) &&
+          isMobile
         ) {
           event.preventDefault()
           toggleSidebar()
@@ -112,16 +120,17 @@ const SidebarProvider = React.forwardRef<
 
       window.addEventListener("keydown", handleKeyDown)
       return () => window.removeEventListener("keydown", handleKeyDown)
-    }, [toggleSidebar])
+    }, [toggleSidebar, isMobile])
 
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.
-    const state = open ? "expanded" : "collapsed"
+    // On desktop, sidebar is always expanded
+    const state = (isMobile ? open : true) ? "expanded" : "collapsed"
 
     const contextValue = React.useMemo<SidebarContext>(
       () => ({
         state,
-        open,
+        open: isMobile ? open : true, // Always open on desktop
         setOpen,
         isMobile,
         openMobile,


### PR DESCRIPTION
Implement a responsive sidebar that is always open on desktop and toggleable on mobile, and center the chat page header.

---
<a href="https://cursor.com/background-agent?bcId=bc-69307c1e-2fd4-48b5-9f34-7e0aecb869a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-69307c1e-2fd4-48b5-9f34-7e0aecb869a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

